### PR TITLE
Fix with respect to the last Sage version

### DIFF
--- a/train_track/free_group.py
+++ b/train_track/free_group.py
@@ -963,7 +963,7 @@ class FreeGroup_class(FreeGroup_class_sage):
             sage: G([1, 2, -2, 1, 1, -2]) # indirect doctest
             a^3*b^-1
 
-            sage: G( G._gap_gens()[0] )
+            sage: G( G.gap().GeneratorsOfGroup()[0] )
             a
             sage: type(_)
             <class 'train_track.free_group.FreeGroup_class_with_category.element_class'>

--- a/train_track/free_group.py
+++ b/train_track/free_group.py
@@ -259,7 +259,7 @@ class FreeGroupElement(ElementLibGAP):
                 else:
                     i = i+1
             AbstractWordTietzeWord = libgap.eval('AbstractWordTietzeWord')
-            x = AbstractWordTietzeWord(l, parent._gap_gens())
+            x = AbstractWordTietzeWord(l, parent.gap().GeneratorsOfGroup())
         ElementLibGAP.__init__(self, parent, x)
 
     def __hash__(self):

--- a/train_track/free_group_automorphism.py
+++ b/train_track/free_group_automorphism.py
@@ -27,10 +27,13 @@ EXAMPLES::
 # *****************************************************************************
 
 from __future__ import print_function, absolute_import
+
+import functools
+
 from sage.combinat.words.morphism import WordMorphism
 from .free_group import FreeGroup, FreeGroupElement
 
-
+@functools.total_ordering
 class FreeGroupMorphism(object):
     def __init__(self, data, domain=None, codomain=None):
         r"""
@@ -372,31 +375,39 @@ class FreeGroupMorphism(object):
         """
         return "Morphism from {} to {}: {}".format(self._domain, self._codomain, str(self))
 
-    def __cmp__(self, other):
+    def __eq__(self, other):
+        if type(self) is not type(other):
+            return NotImplemented
+
+        return self.domain() == other.domain() and \
+               self.codomain() == other.codomain() and \
+               all(self(a) == other(a) for a in self.domain().gens())
+
+    def __lt__(self, other):
         """
         EXAMPLES::
 
             sage: from train_track import *
             sage: phi1 = FreeGroupMorphism('a->ab,b->A')
             sage: phi2 = FreeGroupMorphism('a->aba,b->Ab')
-            sage: phi1==phi2
+            sage: phi1 == phi2
             False
-            sage: phi1<=phi2
+            sage: phi1 <= phi2
             True
-
         """
-        if not isinstance(other, FreeGroupMorphism):
-            return ((self.__class__ > other.__class__) -(self.__class__ < other.__class__))
+        if type(self) is not type(other):
+            return NotImplemented
+
         if self.domain() != other.domain():
-            return ((self.domain() > other.domain()) - (self.domain() < other.domain()))
+            return self.domain() < other.domain()
         if self.codomain() != other.codomain():
-            return ((self.codomain() > other.codomain()) -(self.codomain() < other.codomain()))
+            return self.codomain() < other.codomain()
 
         for a in self.domain().gens():
-            test = ((self(a) > other(a)) - (self(a) < other(a)))
-            if test:
-                return test
-        return 0
+            if self(a) != other(a):
+                return self(a) < other(a)
+
+        return False
 
     def domain(self):
         """

--- a/train_track/inverse_graph.py
+++ b/train_track/inverse_graph.py
@@ -1511,8 +1511,8 @@ class MetricGraph(GraphWithInverses):
         if lengths is None:
             lengths = dict((a, 1) for a in self.alphabet())
         else:
-            for a in lengths.keys():
-                lengths[self.alphabet().inverse_letter(a)] = lengths[a]
+            invert = self.alphabet().inverse_letter
+            lengths.update([(invert(a), l) for a,l in lengths.items()])
 
         self._length = lengths
 

--- a/train_track/marked_graph.py
+++ b/train_track/marked_graph.py
@@ -495,8 +495,8 @@ class MarkedMetricGraph(MarkedGraph, MetricGraph):
         if length is None:
             length = dict((a, 1) for a in self.alphabet())
         else:
-            for a in length.keys():
-                length[self.alphabet().inverse_letter(a)] = length[a]
+            invert = self.alphabet().inverse_letter
+            length.update([(invert(a), l) for a, l in length.items()])
 
         self._length = length
 

--- a/train_track/train_track_map.py
+++ b/train_track/train_track_map.py
@@ -1442,10 +1442,13 @@ class TrainTrackMap(GraphSelfMap):
 
             sage: from train_track import *
             sage: from train_track.train_track_map import TrainTrackMap
-            sage: phi=FreeGroupAutomorphism("a->bca,b->bcacacb,c->cac")
-            sage: f=TrainTrackMap(phi.rose_representative())
-            sage: f.ideal_whitehead_graph()
+            sage: phi = FreeGroupAutomorphism("a->bca,b->bcacacb,c->cac")
+            sage: f = TrainTrackMap(phi.rose_representative())
+            sage: G = f.ideal_whitehead_graph()
+            sage: G
             Graph on 6 vertices
+            sage: G.vertices(sort=False)
+            ['B', 'C', 'b', 'c', 'loop', word: aBCAbc]
 
         .. WARNING:
 
@@ -1676,8 +1679,11 @@ class TrainTrackMap(GraphSelfMap):
 
         .. [Pfaff] C. Pfaff, Out(F_3) Index realization, arXiv:1311.4490.
         """
+        # NOTE: the vertices of the ideal Whitehead graph are a mix of strings and
+        # FiniteWord. These can not be compared and many graph algorithms just fail
+        # because of that.
         l = [len(c) - 2
-             for c in self.ideal_whitehead_graph().connected_components()]
+            for c in self.ideal_whitehead_graph().connected_components(sort=False)]
         return [i for i in l if i > 0]
 
     def blow_up_vertices(self, germ_components):


### PR DESCRIPTION
Compatibility with SageMath 9.3.beta5
- `_gap_gens` should be replaced by `gap().GeneratorsOfGroup()`
- comparison do not use `__cmp__` anymore
- graphs become more complicated to use in the situation where vertices can not be compared