### PR TITLE
Fix import error and deprecation warning

### DIFF
--- a/train_track/convex_core.py
+++ b/train_track/convex_core.py
@@ -36,7 +36,7 @@ EXAMPLES::
 # *****************************************************************************
 from __future__ import print_function, absolute_import
 from sage.combinat.words.word import Word
-from sage.graphs.graph import DiGraph
+from sage.graphs.digraph import DiGraph
 from .inverse_graph import MetricGraph
 from .graph_map import GraphMap
 from .free_group_automorphism import FreeGroupAutomorphism

--- a/train_track/inverse_graph.py
+++ b/train_track/inverse_graph.py
@@ -29,7 +29,7 @@ EXAMPLES::
 # *****************************************************************************
 
 from __future__ import print_function, absolute_import
-from sage.graphs.graph import DiGraph
+from sage.graphs.digraph import DiGraph
 from sage.combinat.words.word import Word
 from .inverse_alphabet import AlphabetWithInverses
 

--- a/train_track/inverse_graph.py
+++ b/train_track/inverse_graph.py
@@ -645,6 +645,8 @@ class GraphWithInverses(DiGraph):
 
         - ``edge_list``  -- (default: ``None``) list of edge
 
+        - ``sort`` -- (default: ``False``) whether to sort the output
+
         OUTPUT:
 
         List of Connected components (each as a list of
@@ -658,7 +660,7 @@ class GraphWithInverses(DiGraph):
             [[0], [1]]
         """
         if edge_list is None:
-            return DiGraph.connected_components(self)
+            return DiGraph.connected_components(self, sort=False)
         components = []
         vertices = []
         for e in edge_list:


### PR DESCRIPTION
We
- fix the import error of `DiGraph` (fixes #22)
- set `sort=False` in the call to `connected_components` of sage `DiGraph` to avoid a deprecation warning